### PR TITLE
Removed hardcoded visualization source and set to variable

### DIFF
--- a/general.json
+++ b/general.json
@@ -680,7 +680,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "u5eohEYnz"
+            "uid": "${query0}"
           },
           "exemplar": true,
           "expr": "(java_lang_OperatingSystem_ProcessCpuLoad * 1000)",
@@ -820,7 +820,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "u5eohEYnz"
+            "uid": "${query0}"
           },
           "exemplar": true,
           "expr": "100*(jvm_memory_bytes_used{area=\"heap\"}/jvm_memory_bytes_max{area=\"heap\"})",
@@ -1156,7 +1156,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "u5eohEYnz"
+            "uid": "${query0}"
           },
           "exemplar": true,
           "expr": "( Catalina_ThreadPool_currentThreadCount / Catalina_ThreadPool_maxThreads) * 100",
@@ -1248,7 +1248,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "u5eohEYnz"
+            "uid": "${query0}"
           },
           "exemplar": true,
           "expr": "increase(Catalina_GlobalRequestProcessor_requestCount{}[5m])",
@@ -1340,7 +1340,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "u5eohEYnz"
+            "uid": "${query0}"
           },
           "exemplar": true,
           "expr": "increase(Catalina_GlobalRequestProcessor_errorCount{}[5m])",
@@ -1432,7 +1432,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "u5eohEYnz"
+            "uid": "${query0}"
           },
           "exemplar": true,
           "expr": "increase(Catalina_GlobalRequestProcessor_processingTime{}[10m]) / increase(Catalina_GlobalRequestProcessor_requestCount{}[10m])",
@@ -1520,7 +1520,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "u5eohEYnz"
+            "uid": "${query0}"
           },
           "exemplar": true,
           "expr": "Catalina_Manager_activeSessions",
@@ -1531,7 +1531,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "u5eohEYnz"
+            "uid": "${query0}"
           },
           "exemplar": true,
           "expr": "Catalina_Manager_rejectedSessions",
@@ -1686,7 +1686,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "u5eohEYnz"
+            "uid": "${query0}"
           },
           "exemplar": true,
           "expr": "(com_atlassian_jira_BasicDataSource_NumActive{connectionpool=\"connections\"} / com_atlassian_jira_BasicDataSource_MaxTotal{connectionpool=\"connections\"}) * 100",

--- a/response-times.json
+++ b/response-times.json
@@ -138,7 +138,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "u5eohEYnz"
+            "uid": "${query0}"
           },
           "exemplar": true,
           "expr": "# We do this because the average of averages is not the real average. We must weigh them by the count\nsum without (instance) ((com_atlassian_jira_metrics_Mean{category00=\"search\",name=\"index\"}) * \n(delta(com_atlassian_jira_metrics_Count{category00=\"search\",name=\"index\"}[5m])))",
@@ -363,7 +363,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "u5eohEYnz"
+            "uid": "${query0}"
           },
           "exemplar": true,
           "expr": "sum without (instance) (increase(com_atlassian_jira_metrics_Count{category00=\"search\", name=\"index\"}[5m]))",


### PR DESCRIPTION
Small update to change the hard-coded visualization source from "u5eohEYnz" to "${query0}" for the following 2 dashboards so they'll work out of the box:
- https://github.com/atlassian-labs/Jira-DC-Grafana-Dashboards/blob/main/general.json
- https://github.com/atlassian-labs/Jira-DC-Grafana-Dashboards/blob/main/response-times.json
