### PR TITLE
DCCLIP-513: refactor database load dashboard

### DIFF
--- a/database-load.json
+++ b/database-load.json
@@ -72,7 +72,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${query0}"
+        "uid": "$datasource"
       },
       "description": "Measures how much load a plugin is putting on the database\n\nThis underpins all DB operations in Jira, which means the db.ao and the db.sal metrics here are a subset.\n\nIf a plugin triggers SQL queries that are abnormal in quantity or duration, contact the app vendor to investigate. The invokerPluginKey tag shows which plugin is doing something that results in database queries being executed.\n\nThere is an optional tag that can be enabled sql which can be used for debugging exactly what the database queries are. It’s not recommended to enable this optional tag in production, it will lead to rapidly growing memory consumption.",
       "fieldConfig": {
@@ -148,13 +148,13 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${query0}"
+            "uid": "$datasource"
           },
           "editorMode": "code",
           "exemplar": true,
           "expr": "# We do this because the average of averages is not the real average. We must weigh them by the count\nsum without (instance) ((com_atlassian_jira_metrics_Mean{name=\"executionTime\", category00=\"db\", category01=\"core\"}) * \n(delta(com_atlassian_jira_metrics_Count{name=\"executionTime\", category00=\"db\", category01=\"core\"}[5m])))\n",
           "interval": "",
-          "legendFormat": "{{tag_invokerPluginKey}}",
+          "legendFormat": "{{ instance }} {{tag_invokerPluginKey}}",
           "range": true,
           "refId": "A"
         }
@@ -165,7 +165,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${query0}"
+        "uid": "$datasource"
       },
       "description": "Measures how long it takes for a DB Query to be executed from being provided a SQL statement to providing the results. \n\nThis underpins all DB operations in Jira, which means the db.ao and the db.sal metrics here are a subset.\n\nIf a plugin triggers SQL queries that are abnormal in quantity or duration, contact the app vendor to investigate. The invokerPluginKey tag shows which plugin is doing something that results in database queries being executed.\n\nThere is an optional tag that can be enabled sql which can be used for debugging exactly what the database queries are. It’s not recommended to enable this optional tag in production, it will lead to rapidly growing memory consumption.",
       "fieldConfig": {
@@ -222,7 +222,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${query0}"
+            "uid": "$datasource"
           },
           "exemplar": false,
           "expr": "avg without (instance, tag_query, category00, category01) (com_atlassian_jira_metrics_Mean{name=\"executionTime\", category00=\"db\", category01=\"core\"})",
@@ -235,7 +235,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${query0}"
+            "uid": "$datasource"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -250,7 +250,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${query0}"
+            "uid": "$datasource"
           },
           "exemplar": false,
           "expr": "max without (instance, tag_query, category00, category01) (com_atlassian_jira_metrics_99thPercentile{name=\"executionTime\", category00=\"db\", category01=\"core\"})",
@@ -303,7 +303,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${query0}"
+        "uid": "$datasource"
       },
       "description": "Measures how long it takes for a DB Query to be executed from being provided a SQL statement to providing the results. \n\nThis underpins all DB operations in Jira, which means the db.ao and the db.sal metrics here are a subset.\n\nIf a plugin triggers SQL queries that are abnormal in quantity or duration, contact the app vendor to investigate. The invokerPluginKey tag shows which plugin is doing something that results in database queries being executed.\n\nThere is an optional tag that can be enabled sql which can be used for debugging exactly what the database queries are. It’s not recommended to enable this optional tag in production, it will lead to rapidly growing memory consumption.",
       "fieldConfig": {
@@ -379,7 +379,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${query0}"
+            "uid": "$datasource"
           },
           "editorMode": "code",
           "exemplar": true,
@@ -396,7 +396,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${query0}"
+        "uid": "$datasource"
       },
       "description": "Measures how long it takes for a DB Query to be executed from being provided a SQL statement to providing the results. \n\nThis underpins all DB operations in Jira, which means the db.ao and the db.sal metrics here are a subset.\n\nIf a plugin triggers SQL queries that are abnormal in quantity or duration, contact the app vendor to investigate. The invokerPluginKey tag shows which plugin is doing something that results in database queries being executed.\n\nThere is an optional tag that can be enabled sql which can be used for debugging exactly what the database queries are. It’s not recommended to enable this optional tag in production, it will lead to rapidly growing memory consumption.",
       "editable": false,
@@ -479,13 +479,13 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${query0}"
+            "uid": "$datasource"
           },
           "exemplar": true,
           "expr": "sum without (instance, tag_entityType) (com_atlassian_jira_metrics_Count{category00=\"db\", category01=\"core\", name=\"executionTime\"})",
           "hide": false,
           "interval": "",
-          "legendFormat": "{{tag_invokerPluginKey}}",
+          "legendFormat": "{{ instance }} {{tag_invokerPluginKey}}",
           "refId": "A"
         }
       ],
@@ -495,7 +495,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${query0}"
+        "uid": "$datasource"
       },
       "description": "Measures how long it takes for a DB Query to be executed from being provided a SQL statement to providing the results. \n\nThis underpins all DB operations in Jira, which means the db.ao and the db.sal metrics here are a subset.\n\nIf a plugin triggers SQL queries that are abnormal in quantity or duration, contact the app vendor to investigate. The invokerPluginKey tag shows which plugin is doing something that results in database queries being executed.\n\nThere is an optional tag that can be enabled sql which can be used for debugging exactly what the database queries are. It’s not recommended to enable this optional tag in production, it will lead to rapidly growing memory consumption.",
       "fieldConfig": {
@@ -571,13 +571,13 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${query0}"
+            "uid": "$datasource"
           },
           "editorMode": "code",
           "exemplar": true,
           "expr": "# We do this because the average of averages is not the real average. We must weigh them by the count\n(sum without (instance) ((com_atlassian_jira_metrics_Mean{name=\"executionTime\", category00=\"db\", category01=\"core\"}) * \n(delta(com_atlassian_jira_metrics_Count{name=\"executionTime\", category00=\"db\", category01=\"core\"}[5m]))) /\n(sum without (instance) (delta(com_atlassian_jira_metrics_Count{name=\"executionTime\", category00=\"db\", category01=\"core\"}[5m]))))\n",
           "interval": "",
-          "legendFormat": "{{tag_invokerPluginKey}}",
+          "legendFormat": "{{ instance }} {{tag_invokerPluginKey}}",
           "range": true,
           "refId": "A"
         }
@@ -608,7 +608,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${query0}"
+        "uid": "$datasource"
       },
       "description": "Measures how long an AO operation (create, find, delete, deleteWithSQL, get, stream, count) that uses the Entity Manager takes.\n\nThe operation query might be long running, or the database is under load. Contact the vendor responsible and investigate if long running queries are expected.",
       "editable": false,
@@ -691,13 +691,13 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${query0}"
+            "uid": "$datasource"
           },
           "exemplar": true,
           "expr": "# We do this because the average of averages is not the real average. We must weigh them by the count\n(sum without (instance, tag_entityType) ((com_atlassian_jira_metrics_Mean{category00=\"db\", category01=\"ao\", category02=\"entityManager\"}) * \n(delta(com_atlassian_jira_metrics_Count{category00=\"db\", category01=\"ao\", category02=\"entityManager\"}[5m]))))\n",
           "hide": false,
           "interval": "",
-          "legendFormat": "{{tag_invokerPluginKey}} - {{name}}",
+          "legendFormat": "{{ instance }} {{tag_invokerPluginKey}} - {{name}}",
           "refId": "A"
         }
       ],
@@ -707,7 +707,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${query0}"
+        "uid": "$datasource"
       },
       "description": "Measures how long an AO operation (create, find, delete, deleteWithSQL, get, stream, count) that uses the Entity Manager takes.\n\nThe operation query might be long running, or the database is under load. Contact the vendor responsible and investigate if long running queries are expected.",
       "editable": false,
@@ -790,13 +790,13 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${query0}"
+            "uid": "$datasource"
           },
           "exemplar": true,
           "expr": "# We do this because the average of averages is not the real average. We must weigh them by the count\n(sum without (instance, tag_entityType) ((com_atlassian_jira_metrics_Mean{category00=\"db\", category01=\"ao\", category02=\"entityManager\"}) * \n(delta(com_atlassian_jira_metrics_Count{category00=\"db\", category01=\"ao\", category02=\"entityManager\"}[5m])))) /\n(sum without (instance, tag_entityType) (delta(com_atlassian_jira_metrics_Count{category00=\"db\", category01=\"ao\", category02=\"entityManager\"}[5m])))\n",
           "hide": false,
           "interval": "",
-          "legendFormat": "{{tag_invokerPluginKey}} - {{name}}",
+          "legendFormat": "{{ instance }} {{tag_invokerPluginKey}} - {{name}}",
           "refId": "A"
         }
       ],
@@ -806,7 +806,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${query0}"
+        "uid": "$datasource"
       },
       "description": "Measures the total count of AO operations (create, find, delete, deleteWithSQL, get, stream, count) by the plugins.\n\nThe operation query might be long running, or the database is under load. Contact the vendor responsible and investigate if long running queries are expected.",
       "editable": false,
@@ -889,13 +889,13 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${query0}"
+            "uid": "$datasource"
           },
           "exemplar": true,
           "expr": "sum without (instance, tag_entityType) (com_atlassian_jira_metrics_Count{category00=\"db\", category01=\"ao\", category02=\"entityManager\"})",
           "hide": false,
           "interval": "",
-          "legendFormat": "{{tag_invokerPluginKey}} - {{name}} ",
+          "legendFormat": "{{ instance }} {{tag_invokerPluginKey}} - {{name}} ",
           "refId": "A"
         }
       ],
@@ -905,7 +905,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${query0}"
+        "uid": "$datasource"
       },
       "description": "Measures how long an AO operation (create, find, delete, deleteWithSQL, get, stream, count) that uses the Entity Manager takes.\n\nThe operation query might be long running, or the database is under load. Contact the vendor responsible and investigate if long running queries are expected.",
       "editable": false,
@@ -988,12 +988,12 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${query0}"
+            "uid": "$datasource"
           },
           "exemplar": true,
           "expr": "com_atlassian_jira_metrics_99thPercentile{category00=\"db\", category01=\"ao\", category02=\"entityManager\"}",
           "interval": "",
-          "legendFormat": "{{tag_invokerPluginKey}} - {{name}} - {{tag_entityType}}",
+          "legendFormat": "{{ instance }} {{tag_invokerPluginKey}} - {{name}} - {{tag_entityType}}",
           "refId": "A"
         }
       ],
@@ -1024,7 +1024,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${query0}"
+        "uid": "$datasource"
       },
       "description": "",
       "editable": false,
@@ -1107,13 +1107,13 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${query0}"
+            "uid": "$datasource"
           },
           "exemplar": true,
           "expr": "# We do this because the average of averages is not the real average. We must weigh them by the count\n(sum without (instance, tag_taskName) ((com_atlassian_jira_metrics_Mean{category00=\"db\", category01=\"ao\", name=\"executeInTransaction\"}) * \n(delta(com_atlassian_jira_metrics_Count{category00=\"db\", category01=\"ao\", name=\"executeInTransaction\"}[5m]))))\n",
           "hide": false,
           "interval": "",
-          "legendFormat": "{{tag_invokerPluginKey}}",
+          "legendFormat": "{{ instance }} {{tag_invokerPluginKey}}",
           "refId": "A"
         }
       ],
@@ -1123,7 +1123,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${query0}"
+        "uid": "$datasource"
       },
       "description": "",
       "editable": false,
@@ -1206,13 +1206,13 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${query0}"
+            "uid": "$datasource"
           },
           "exemplar": true,
           "expr": "# We do this because the average of averages is not the real average. We must weigh them by the count\n(sum without (instance, tag_taskName) ((com_atlassian_jira_metrics_Mean{category00=\"db\", category01=\"ao\", name=\"executeInTransaction\"}) * \n(delta(com_atlassian_jira_metrics_Count{category00=\"db\", category01=\"ao\", name=\"executeInTransaction\"}[5m])))) /\n(sum without (instance, tag_taskName) (delta(com_atlassian_jira_metrics_Count{category00=\"db\", category01=\"ao\", name=\"executeInTransaction\"}[5m])))\n",
           "hide": false,
           "interval": "",
-          "legendFormat": "{{tag_invokerPluginKey}}",
+          "legendFormat": "{{ instance }} {{tag_invokerPluginKey}}",
           "refId": "A"
         }
       ],
@@ -1222,7 +1222,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${query0}"
+        "uid": "$datasource"
       },
       "description": "",
       "editable": false,
@@ -1305,13 +1305,13 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${query0}"
+            "uid": "$datasource"
           },
           "exemplar": true,
           "expr": "sum without (instance, tag_taskName) (com_atlassian_jira_metrics_Count{category00=\"db\", category01=\"ao\", name=\"executeInTransaction\"})",
           "hide": false,
           "interval": "",
-          "legendFormat": "{{tag_invokerPluginKey}}",
+          "legendFormat": "{{ instance }} {{tag_invokerPluginKey}}",
           "refId": "A"
         }
       ],
@@ -1321,7 +1321,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${query0}"
+        "uid": "$datasource"
       },
       "description": "Measures how long an AO operation (create, find, delete, deleteWithSQL, get, stream, count) that uses the Entity Manager takes.\n\nThe operation query might be long running, or the database is under load. Contact the vendor responsible and investigate if long running queries are expected.",
       "editable": false,
@@ -1404,12 +1404,12 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${query0}"
+            "uid": "$datasource"
           },
           "exemplar": true,
           "expr": "com_atlassian_jira_metrics_99thPercentile{category00=\"db\", category01=\"ao\", name=\"executeInTransaction\"}",
           "interval": "",
-          "legendFormat": "{{tag_invokerPluginKey}} - {{tag_taskName}}",
+          "legendFormat": "{{ instance }} {{tag_invokerPluginKey}} - {{tag_taskName}}",
           "refId": "A"
         }
       ],
@@ -1419,7 +1419,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${query0}"
+        "uid": "$datasource"
       },
       "description": "Measures how long an AO transaction takes, when executed inside the TransactionCallBack. This is mainly used by Confluence plugins.\n\nThe transaction can have many AO operations, it can be either there are too many operations or the query is long running, or the database is under load. Contact the vendor responsible and investigate if long running queries are expected.",
       "editable": false,
@@ -1473,7 +1473,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${query0}"
+            "uid": "$datasource"
           },
           "exemplar": true,
           "expr": "sum without (instance, tag_taskName, tag_invokerPluginKey) (com_atlassian_jira_metrics_Value{category00=\"db\",category01=\"ao\",name=\"executeInTransaction\", tag_statistic=\"active\"})",
@@ -1488,7 +1488,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${query0}"
+        "uid": "$datasource"
       },
       "description": "Measures how long an AO transaction takes, when executed inside the TransactionCallBack. This is mainly used by Confluence plugins.\n\nThe transaction can have many AO operations, it can be either there are too many operations or the query is long running, or the database is under load. Contact the vendor responsible and investigate if long running queries are expected.",
       "editable": false,
@@ -1571,12 +1571,12 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${query0}"
+            "uid": "$datasource"
           },
           "exemplar": true,
           "expr": "sum without (instance) (com_atlassian_jira_metrics_Value{category00=\"db\",category01=\"ao\",name=\"executeInTransaction\", tag_statistic=\"active\"})",
           "interval": "",
-          "legendFormat": "{{ tag_invokerPluginKey }} - {{tag_taskName}} (task)",
+          "legendFormat": "{{ instance }} {{ tag_invokerPluginKey }} - {{tag_taskName}} (task)",
           "refId": "A"
         }
       ],
@@ -1607,7 +1607,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${query0}"
+        "uid": "$datasource"
       },
       "description": "",
       "editable": false,
@@ -1690,13 +1690,13 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${query0}"
+            "uid": "$datasource"
           },
           "exemplar": true,
           "expr": "# We do this because the average of averages is not the real average. We must weigh them by the count\n(sum without (instance, tag_taskName) ((com_atlassian_jira_metrics_Mean{category00=\"db\", category01=\"sal\", name=\"transactionalExecutor\"}) * \n(delta(com_atlassian_jira_metrics_Count{category00=\"db\", category01=\"sal\", name=\"transactionalExecutor\"}[5m]))))\n",
           "hide": false,
           "interval": "",
-          "legendFormat": "{{tag_invokerPluginKey}}",
+          "legendFormat": "{{ instance }} {{tag_invokerPluginKey}}",
           "refId": "A"
         }
       ],
@@ -1706,7 +1706,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${query0}"
+        "uid": "$datasource"
       },
       "description": "",
       "editable": false,
@@ -1789,13 +1789,13 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${query0}"
+            "uid": "$datasource"
           },
           "exemplar": true,
           "expr": "# We do this because the average of averages is not the real average. We must weigh them by the count\n(sum without (instance, tag_taskName) ((com_atlassian_jira_metrics_Mean{category00=\"db\", category01=\"ao\", name=\"executeInTransaction\"}) * \n(delta(com_atlassian_jira_metrics_Count{category00=\"db\", category01=\"ao\", name=\"executeInTransaction\"}[5m])))) /\n(sum without (instance, tag_taskName) (delta(com_atlassian_jira_metrics_Count{category00=\"db\", category01=\"ao\", name=\"executeInTransaction\"}[5m])))\n",
           "hide": false,
           "interval": "",
-          "legendFormat": "{{tag_invokerPluginKey}}",
+          "legendFormat": "{{ instance }} {{tag_invokerPluginKey}}",
           "refId": "A"
         }
       ],
@@ -1805,7 +1805,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${query0}"
+        "uid": "$datasource"
       },
       "description": "",
       "editable": false,
@@ -1888,13 +1888,13 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${query0}"
+            "uid": "$datasource"
           },
           "exemplar": true,
           "expr": "sum without (instance, tag_taskName) (com_atlassian_jira_metrics_Count{category00=\"db\", category01=\"sal\", name=\"transactionalExecutor\"})",
           "hide": false,
           "interval": "",
-          "legendFormat": "{{tag_invokerPluginKey}}",
+          "legendFormat": "{{ instance }} {{tag_invokerPluginKey}}",
           "refId": "A"
         }
       ],
@@ -1904,7 +1904,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${query0}"
+        "uid": "$datasource"
       },
       "description": "Measures how long an AO operation (create, find, delete, deleteWithSQL, get, stream, count) that uses the Entity Manager takes.\n\nThe operation query might be long running, or the database is under load. Contact the vendor responsible and investigate if long running queries are expected.",
       "editable": false,
@@ -1987,12 +1987,12 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${query0}"
+            "uid": "$datasource"
           },
           "exemplar": true,
           "expr": "com_atlassian_jira_metrics_99thPercentile{category00=\"db\", category01=\"sal\", name=\"transactionalExecutor\"}",
           "interval": "",
-          "legendFormat": "{{ tag_invokerPluginKey }} - {{tag_taskName}} (task)",
+          "legendFormat": "{{ instance }} {{ tag_invokerPluginKey }} - {{tag_taskName}} (task)",
           "refId": "A"
         }
       ],
@@ -2002,7 +2002,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${query0}"
+        "uid": "$datasource"
       },
       "description": "Measures how long an SAL transaction takes, when executed inside the DefaultTransactionalExecutor.\n\nThe transaction can have many SAL operations, it can be either there are too many operations or the query is long running, or the database is under load. Contact the vendor responsible and investigate if long running queries are expected.",
       "editable": false,
@@ -2056,7 +2056,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${query0}"
+            "uid": "$datasource"
           },
           "exemplar": true,
           "expr": "sum without (instance, tag_taskName, tag_invokerPluginKey) (com_atlassian_jira_metrics_Value{category00=\"db\",category01=\"sal\",name=\"transactionalExecutor\", tag_statistic=\"active\"})",
@@ -2071,7 +2071,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${query0}"
+        "uid": "$datasource"
       },
       "description": "Measures how long an SAL transaction takes, when executed inside the DefaultTransactionalExecutor.\n\nThe transaction can have many SAL operations, it can be either there are too many operations or the query is long running, or the database is under load. Contact the vendor responsible and investigate if long running queries are expected.",
       "editable": false,
@@ -2154,12 +2154,12 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${query0}"
+            "uid": "$datasource"
           },
           "exemplar": true,
           "expr": "sum without (instance) (com_atlassian_jira_metrics_Value{category00=\"db\",category01=\"sal\",name=\"transactionalExecutor\",tag_statistic=\"active\"})",
           "interval": "",
-          "legendFormat": "{{ tag_invokerPluginKey }} - {{tag_taskName}} (task)",
+          "legendFormat": "{{ instance }} {{ tag_invokerPluginKey }} - {{tag_taskName}} (task)",
           "refId": "A"
         }
       ],
@@ -2190,7 +2190,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${query0}"
+        "uid": "$datasource"
       },
       "description": "Measures how long an App is taking to upgrade a part of the data that it stores in the database.\n\nUpgrade tasks happen when an App is both updated and enabled, during this time the App’s functionality will probably be unavailable, and it may temporarily increase load on the database and the node the upgrade task is running on.\n\nIf an App stores a lot of data in database then this may take a while to run, if possible, try to schedule upgrading Apps with large amounts of data in off-peak hours.",
       "editable": false,
@@ -2244,7 +2244,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${query0}"
+            "uid": "$datasource"
           },
           "exemplar": true,
           "expr": "sum without (instance, tag_fromPluginKey, tag_taskName) (com_atlassian_jira_metrics_Value{category00=\"db\",category01=\"ao\",name=\"upgradeTask\",tag_statistic=\"active\",tag_subCategory=\"current\"})",
@@ -2259,7 +2259,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${query0}"
+        "uid": "$datasource"
       },
       "description": "Measures how long an App is taking to upgrade a part of the data that it stores in the database.\n\nUpgrade tasks happen when an App is both updated and enabled, during this time the App’s functionality will probably be unavailable, and it may temporarily increase load on the database and the node the upgrade task is running on.\n\nIf an App stores a lot of data in database then this may take a while to run, if possible, try to schedule upgrading Apps with large amounts of data in off-peak hours.",
       "editable": false,
@@ -2342,12 +2342,12 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${query0}"
+            "uid": "$datasource"
           },
           "exemplar": true,
           "expr": "sum without (instance) (com_atlassian_jira_metrics_Value{category00=\"db\",category01=\"ao\",name=\"upgradeTask\",tag_statistic=\"active\",tag_subCategory=\"current\"})",
           "interval": "",
-          "legendFormat": "{{ tag_invokerPluginKey }} - {{tag_taskName}} (task)",
+          "legendFormat": "{{ instance }} {{ tag_invokerPluginKey }} - {{tag_taskName}} (task)",
           "refId": "A"
         }
       ],
@@ -2358,20 +2358,22 @@
   "refresh": "",
   "schemaVersion": 34,
   "style": "dark",
-  "tags": [],
+  "tags": [
+    "jira"
+  ],
   "templating": {
     "list": [
       {
         "current": {
           "selected": true,
-          "text": "1Bulldog",
-          "value": "1Bulldog"
+          "text": "default",
+          "value": "default"
         },
         "hide": 0,
         "includeAll": false,
-        "label": "Datasource",
+        "label": "Data Source",
         "multi": false,
-        "name": "query0",
+        "name": "datasource",
         "options": [],
         "query": "prometheus",
         "queryValue": "",
@@ -2383,13 +2385,12 @@
     ]
   },
   "time": {
-    "from": "now-1h",
+    "from": "now-6h",
     "to": "now"
   },
   "timepicker": {},
-  "timezone": "Europe/Warsaw",
-  "title": "Database load",
-  "uid": "qqVaZU5nz",
-  "version": 138,
+  "timezone": "",
+  "title": "Jira Database Load",
+  "version": 1,
   "weekStart": ""
 }

--- a/database-load.json
+++ b/database-load.json
@@ -1004,7 +1004,7 @@
       "collapsed": false,
       "datasource": {
         "type": "prometheus",
-        "uid": "UKZbfKl7k"
+        "uid": "$datasource"
       },
       "editable": false,
       "error": false,
@@ -1587,7 +1587,7 @@
       "collapsed": false,
       "datasource": {
         "type": "prometheus",
-        "uid": "UKZbfKl7k"
+        "uid": "$datasource"
       },
       "editable": false,
       "error": false,
@@ -2170,7 +2170,7 @@
       "collapsed": false,
       "datasource": {
         "type": "prometheus",
-        "uid": "UKZbfKl7k"
+        "uid": "$datasource"
       },
       "editable": false,
       "error": false,


### PR DESCRIPTION
This PR refactored database load dashboard to be more generic and Kubernetes-friendly:
- updated variable naming,
- narrowed down legend format to instance level,
- unified time to be 6h from now,
- removed hardcoded uid,
- removed timezone, 
- set dashboard version to 1,
- added `Jira` to dashboard name,
- added tag `jira`. 