### PR TITLE
DCCLIP-513: refactor general dashboard

### DIFF
--- a/general.json
+++ b/general.json
@@ -55,7 +55,7 @@
       "colorValue": false,
       "datasource": {
         "type": "prometheus",
-        "uid": "${query0}"
+        "uid": "$datasource"
       },
       "decimals": 0,
       "editable": false,
@@ -136,7 +136,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${query0}"
+            "uid": "$datasource"
           },
           "exemplar": true,
           "expr": "up",
@@ -156,7 +156,7 @@
       "colorValue": false,
       "datasource": {
         "type": "prometheus",
-        "uid": "${query0}"
+        "uid": "$datasource"
       },
       "decimals": 0,
       "editable": false,
@@ -222,10 +222,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${query0}"
+            "uid": "$datasource"
           },
           "exemplar": true,
-          "expr": "time() - process_start_time_seconds",
+          "expr": "time() - process_start_time_seconds{}",
           "interval": "",
           "legendFormat": "{{instance}}",
           "refId": "A"
@@ -242,7 +242,7 @@
       "colorValue": false,
       "datasource": {
         "type": "prometheus",
-        "uid": "${query0}"
+        "uid": "$datasource"
       },
       "decimals": 0,
       "editable": false,
@@ -308,7 +308,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${query0}"
+            "uid": "$datasource"
           },
           "exemplar": true,
           "expr": "java_lang_Runtime_StartTime{}",
@@ -328,7 +328,7 @@
       "colorValue": false,
       "datasource": {
         "type": "prometheus",
-        "uid": "${query0}"
+        "uid": "$datasource"
       },
       "decimals": 0,
       "editable": false,
@@ -393,7 +393,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${query0}"
+            "uid": "$datasource"
           },
           "exemplar": true,
           "expr": "java_lang_OperatingSystem_AvailableProcessors{}",
@@ -441,7 +441,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "java_lang_OperatingSystem_AvailableProcessors{instance=\"localhost:2991\"}",
+          "expr": "java_lang_OperatingSystem_AvailableProcessors{}",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
@@ -453,7 +453,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${query0}"
+        "uid": "$datasource"
       },
       "editable": false,
       "error": false,
@@ -538,10 +538,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${query0}"
+            "uid": "$datasource"
           },
           "exemplar": true,
-          "expr": "increase(jvm_gc_collection_seconds_sum[5m])",
+          "expr": "increase(jvm_gc_collection_seconds_sum{}[5m])",
           "format": "time_series",
           "interval": "60s",
           "legendFormat": "{{gc}} - {{instance}}",
@@ -591,8 +591,7 @@
             "isDefault": false,
             "name": "",
             "sendReminder": false,
-            "type": "",
-            "uid": "-bCLo527z"
+            "type": ""
           }
         ]
       },
@@ -680,10 +679,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${query0}"
+            "uid": "$datasource"
           },
           "exemplar": true,
-          "expr": "(java_lang_OperatingSystem_ProcessCpuLoad * 1000)",
+          "expr": "(java_lang_OperatingSystem_ProcessCpuLoad{} * 1000)",
           "interval": "",
           "legendFormat": "cpu load - {{instance}}",
           "refId": "A"
@@ -732,8 +731,7 @@
             "isDefault": false,
             "name": "",
             "sendReminder": false,
-            "type": "",
-            "uid": "-bCLo527z"
+            "type": ""
           }
         ]
       },
@@ -820,7 +818,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${query0}"
+            "uid": "$datasource"
           },
           "exemplar": true,
           "expr": "100*(jvm_memory_bytes_used{area=\"heap\"}/jvm_memory_bytes_max{area=\"heap\"})",
@@ -835,7 +833,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${query0}"
+        "uid": "$datasource"
       },
       "description": "",
       "editable": false,
@@ -917,7 +915,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${query0}"
+            "uid": "$datasource"
           },
           "exemplar": true,
           "expr": "increase(jvm_gc_collection_seconds_count{}[5m])",
@@ -933,7 +931,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${query0}"
+        "uid": "$datasource"
       },
       "editable": false,
       "error": false,
@@ -998,13 +996,13 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${query0}"
+            "uid": "$datasource"
           },
           "exemplar": true,
           "expr": "jvm_threads_state{state=\"BLOCKED\"}",
           "hide": false,
           "interval": "",
-          "legendFormat": "{{ state }}",
+          "legendFormat": "{{ instance }} {{ state }}",
           "refId": "D"
         }
       ],
@@ -1068,8 +1066,7 @@
             "isDefault": false,
             "name": "",
             "sendReminder": false,
-            "type": "",
-            "uid": "-bCLo527z"
+            "type": ""
           }
         ]
       },
@@ -1156,10 +1153,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${query0}"
+            "uid": "$datasource"
           },
           "exemplar": true,
-          "expr": "( Catalina_ThreadPool_currentThreadCount / Catalina_ThreadPool_maxThreads) * 100",
+          "expr": "( Catalina_ThreadPool_currentThreadCount{} / Catalina_ThreadPool_maxThreads{}) * 100",
           "interval": "",
           "legendFormat": "used - {{instance}} ({{name}})",
           "refId": "A"
@@ -1248,7 +1245,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${query0}"
+            "uid": "$datasource"
           },
           "exemplar": true,
           "expr": "increase(Catalina_GlobalRequestProcessor_requestCount{}[5m])",
@@ -1340,7 +1337,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${query0}"
+            "uid": "$datasource"
           },
           "exemplar": true,
           "expr": "increase(Catalina_GlobalRequestProcessor_errorCount{}[5m])",
@@ -1432,7 +1429,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${query0}"
+            "uid": "$datasource"
           },
           "exemplar": true,
           "expr": "increase(Catalina_GlobalRequestProcessor_processingTime{}[10m]) / increase(Catalina_GlobalRequestProcessor_requestCount{}[10m])",
@@ -1520,10 +1517,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${query0}"
+            "uid": "$datasource"
           },
           "exemplar": true,
-          "expr": "Catalina_Manager_activeSessions",
+          "expr": "Catalina_Manager_activeSessions{}",
           "interval": "",
           "legendFormat": "active sessions: {{instance}}",
           "refId": "A"
@@ -1531,10 +1528,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${query0}"
+            "uid": "$datasource"
           },
           "exemplar": true,
-          "expr": "Catalina_Manager_rejectedSessions",
+          "expr": "Catalina_Manager_rejectedSessions{}",
           "interval": "",
           "legendFormat": "rejected sessions: {{instance}}",
           "refId": "C"
@@ -1602,8 +1599,7 @@
             "isDefault": false,
             "name": "",
             "sendReminder": false,
-            "type": "",
-            "uid": "-bCLo527z"
+            "type": ""
           }
         ]
       },
@@ -1686,7 +1682,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${query0}"
+            "uid": "$datasource"
           },
           "exemplar": true,
           "expr": "(com_atlassian_jira_BasicDataSource_NumActive{connectionpool=\"connections\"} / com_atlassian_jira_BasicDataSource_MaxTotal{connectionpool=\"connections\"}) * 100",
@@ -1709,7 +1705,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${query0}"
+        "uid": "$datasource"
       },
       "editable": false,
       "error": false,
@@ -1790,7 +1786,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${query0}"
+            "uid": "$datasource"
           },
           "exemplar": true,
           "expr": "com_atlassian_jira_BasicDataSource_NumActive{connectionpool=\"connections\"}",
@@ -1801,7 +1797,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${query0}"
+            "uid": "$datasource"
           },
           "exemplar": true,
           "expr": "com_atlassian_jira_BasicDataSource_NumIdle{connectionpool=\"connections\"}",
@@ -1816,7 +1812,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${query0}"
+        "uid": "$datasource"
       },
       "editable": false,
       "error": false,
@@ -1897,10 +1893,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${query0}"
+            "uid": "$datasource"
           },
           "exemplar": true,
-          "expr": "delta(com_atlassian_jira_db_reads_invocation_count[5m])",
+          "expr": "delta(com_atlassian_jira_db_reads_invocation_count{}[5m])",
           "interval": "",
           "legendFormat": "reads - {{instance}}",
           "refId": "A"
@@ -1908,10 +1904,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${query0}"
+            "uid": "$datasource"
           },
           "exemplar": true,
-          "expr": "delta(com_atlassian_jira_db_writes_invocation_count[5m])",
+          "expr": "delta(com_atlassian_jira_db_writes_invocation_count{}[5m])",
           "interval": "",
           "legendFormat": "writes - {{instance}}",
           "refId": "B"
@@ -1930,14 +1926,14 @@
       {
         "current": {
           "selected": false,
-          "text": "Blitz",
-          "value": "Blitz"
+          "text": "default",
+          "value": "default"
         },
         "hide": 0,
         "includeAll": false,
-        "label": "Datasource",
+        "label": "Data Source",
         "multi": false,
-        "name": "query0",
+        "name": "datasource",
         "options": [],
         "query": "prometheus",
         "queryValue": "",
@@ -1949,13 +1945,12 @@
     ]
   },
   "time": {
-    "from": "now-30m",
+    "from": "now-6h",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "",
-  "title": "General",
-  "uid": "IeEDnNp7z",
-  "version": 67,
+  "title": "Jira General",
+  "version": 1,
   "weekStart": ""
 }

--- a/general.json
+++ b/general.json
@@ -1558,6 +1558,10 @@
       "type": "row"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
       "alert": {
         "alertRuleTags": {},
         "conditions": [
@@ -1607,39 +1611,41 @@
       "error": false,
       "fieldConfig": {
         "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
           "custom": {
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
             "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "barAlignment": 0,
+            "lineWidth": 1,
             "fillOpacity": 5,
             "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineStyle": {
-              "fill": "solid"
-            },
-            "lineWidth": 1,
+            "spanNulls": false,
+            "showPoints": "never",
             "pointSize": 5,
+            "stacking": {
+              "mode": "none",
+              "group": "A"
+            },
+            "axisPlacement": "auto",
+            "axisLabel": "",
+            "axisColorMode": "text",
             "scaleDistribution": {
               "type": "linear"
             },
-            "showPoints": "never",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
+            "axisCenteredZero": false,
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
             },
             "thresholdsStyle": {
               "mode": "off"
+            },
+            "lineStyle": {
+              "fill": "solid"
             }
+          },
+          "color": {
+            "mode": "thresholds"
           },
           "mappings": [],
           "thresholds": {
@@ -1660,21 +1666,23 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 14,
-        "w": 8,
+        "h": 11,
+        "w": 6,
         "x": 0,
         "y": 41
       },
       "id": 10,
       "isNew": false,
       "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom"
-        },
         "tooltip": {
-          "mode": "single"
+          "mode": "single",
+          "sort": "none"
+        },
+        "legend": {
+          "showLegend": true,
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": []
         }
       },
       "span": 0,
@@ -1711,39 +1719,41 @@
       "error": false,
       "fieldConfig": {
         "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
           "custom": {
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
             "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "barAlignment": 0,
+            "lineWidth": 1,
             "fillOpacity": 5,
             "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineStyle": {
-              "fill": "solid"
-            },
-            "lineWidth": 1,
+            "spanNulls": false,
+            "showPoints": "never",
             "pointSize": 5,
+            "stacking": {
+              "mode": "none",
+              "group": "A"
+            },
+            "axisPlacement": "auto",
+            "axisLabel": "",
+            "axisColorMode": "text",
             "scaleDistribution": {
               "type": "linear"
             },
-            "showPoints": "never",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
+            "axisCenteredZero": false,
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
             },
             "thresholdsStyle": {
               "mode": "off"
+            },
+            "lineStyle": {
+              "fill": "solid"
             }
+          },
+          "color": {
+            "mode": "palette-classic"
           },
           "mappings": [],
           "thresholds": {
@@ -1764,21 +1774,23 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 14,
-        "w": 8,
-        "x": 8,
+        "h": 11,
+        "w": 6,
+        "x": 6,
         "y": 41
       },
       "id": 35,
       "isNew": false,
       "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom"
-        },
         "tooltip": {
-          "mode": "single"
+          "mode": "single",
+          "sort": "none"
+        },
+        "legend": {
+          "showLegend": true,
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": []
         }
       },
       "span": 0,
@@ -1818,39 +1830,41 @@
       "error": false,
       "fieldConfig": {
         "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
           "custom": {
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
             "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "barAlignment": 0,
+            "lineWidth": 1,
             "fillOpacity": 5,
             "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineStyle": {
-              "fill": "solid"
-            },
-            "lineWidth": 1,
+            "spanNulls": false,
+            "showPoints": "never",
             "pointSize": 5,
+            "stacking": {
+              "mode": "none",
+              "group": "A"
+            },
+            "axisPlacement": "auto",
+            "axisLabel": "",
+            "axisColorMode": "text",
             "scaleDistribution": {
               "type": "linear"
             },
-            "showPoints": "never",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
+            "axisCenteredZero": false,
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
             },
             "thresholdsStyle": {
               "mode": "off"
+            },
+            "lineStyle": {
+              "fill": "solid"
             }
+          },
+          "color": {
+            "mode": "palette-classic"
           },
           "mappings": [],
           "thresholds": {
@@ -1871,21 +1885,23 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 14,
-        "w": 8,
-        "x": 16,
+        "h": 11,
+        "w": 6,
+        "x": 12,
         "y": 41
       },
       "id": 36,
       "isNew": false,
       "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom"
-        },
         "tooltip": {
-          "mode": "single"
+          "mode": "single",
+          "sort": "none"
+        },
+        "legend": {
+          "showLegend": true,
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": []
         }
       },
       "span": 0,
@@ -1914,6 +1930,99 @@
         }
       ],
       "title": "Reads / Writes",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "barAlignment": 0,
+            "lineWidth": 1,
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "spanNulls": false,
+            "showPoints": "auto",
+            "pointSize": 5,
+            "stacking": {
+              "mode": "none",
+              "group": "A"
+            },
+            "axisPlacement": "auto",
+            "axisLabel": "",
+            "axisColorMode": "text",
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "axisCenteredZero": false,
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 6,
+        "x": 18,
+        "y": 41
+      },
+      "id": 41,
+      "options": {
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        },
+        "legend": {
+          "showLegend": true,
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": []
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "builder",
+          "expr": "com_atlassian_jira_metrics_Mean{category00=\"db\", category01=\"connection\", category02=\"latency\"}",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Database Latency",
       "type": "timeseries"
     }
   ],

--- a/general.json
+++ b/general.json
@@ -2029,7 +2029,9 @@
   "refresh": "",
   "schemaVersion": 34,
   "style": "dark",
-  "tags": [],
+  "tags": [
+    "jira"
+  ],
   "templating": {
     "list": [
       {


### PR DESCRIPTION
This PR refactored general dashboard to be more generic:
- updated variable naming,
- narrowed down legend format to instance level,
- unified time to be 6h from now,
- removed hardcoded uid,
- set dashboard version to 1,
- added `Jira` to dashboard name,
- added tag `jira`,
- added database latency panel.