### PR TITLE
DCCLIP-513: Updated response times dashboard to be more generic.

### DIFF
--- a/response-times.json
+++ b/response-times.json
@@ -138,12 +138,12 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${query0}"
+            "uid": "$datasource"
           },
           "exemplar": true,
           "expr": "# We do this because the average of averages is not the real average. We must weigh them by the count\nsum without (instance) ((com_atlassian_jira_metrics_Mean{category00=\"search\",name=\"index\"}) * \n(delta(com_atlassian_jira_metrics_Count{category00=\"search\",name=\"index\"}[5m])))",
           "interval": "",
-          "legendFormat": "{{ tag_invokerPluginKey }}",
+          "legendFormat": "{{ instance }} {{ tag_invokerPluginKey }}",
           "refId": "A"
         }
       ],
@@ -153,7 +153,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${query0}"
+        "uid": "$datasource"
       },
       "description": "Measures how long it takes for a Lucene index search to take place. \n\nIf a plugin triggers searches that are abnormal in quantity or duration then contact the app vendor to investigate. You can find out which plugin is responsible for the index searches using the invokerPluginKey tag ",
       "fieldConfig": {
@@ -210,7 +210,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${query0}"
+            "uid": "$datasource"
           },
           "exemplar": false,
           "expr": "avg without (instance, tag_query, category00) (com_atlassian_jira_metrics_Mean{category00=\"search\", name=\"index\"})",
@@ -223,7 +223,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${query0}"
+            "uid": "$datasource"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -238,7 +238,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${query0}"
+            "uid": "$datasource"
           },
           "exemplar": false,
           "expr": "max without (instance, tag_query, category00) (com_atlassian_jira_metrics_99thPercentile{category00=\"search\", name=\"index\"})",
@@ -363,12 +363,12 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${query0}"
+            "uid": "$datasource"
           },
           "exemplar": true,
           "expr": "sum without (instance) (increase(com_atlassian_jira_metrics_Count{category00=\"search\", name=\"index\"}[5m]))",
           "interval": "",
-          "legendFormat": "{{ tag_invokerPluginKey }}",
+          "legendFormat": "{{ instance }} {{ tag_invokerPluginKey }}",
           "refId": "A"
         }
       ],
@@ -378,7 +378,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${query0}"
+        "uid": "$datasource"
       },
       "description": "Measures how long it takes for a Lucene index search to take place. \n\nIf a plugin triggers searches that are abnormal in quantity or duration then contact the app vendor to investigate. You can find out which plugin is responsible for the index searches using the invokerPluginKey tag ",
       "fieldConfig": {
@@ -457,13 +457,13 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${query0}"
+            "uid": "$datasource"
           },
           "editorMode": "code",
           "exemplar": true,
           "expr": "com_atlassian_jira_metrics_99thPercentile{category00=\"search\", name=\"index\"}",
           "interval": "",
-          "legendFormat": "{{tag_invokerPluginKey}}",
+          "legendFormat": "{{ instance }} {{tag_invokerPluginKey}}",
           "range": true,
           "refId": "A"
         }
@@ -491,7 +491,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${query0}"
+        "uid": "$datasource"
       },
       "description": "Measures how long web fragment condition will take to determine whether a web fragment should be displayed or not.\n\nWeb fragments conditions determine whether a link or a section on a page should be displayed. Slow web fragment conditions lead to slow page load times especially if they are not cached. Reach out to the app vendor responsible to flag and investigate. ",
       "editable": false,
@@ -573,12 +573,12 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${query0}"
+            "uid": "$datasource"
           },
           "exemplar": true,
           "expr": "# We do this because the average of averages is not the real average. We must weigh them by the count\n(sum without (instance) ((com_atlassian_jira_metrics_Mean{category00=\"web\", category01=\"fragment\", name=\"condition\"}) * \n(delta(com_atlassian_jira_metrics_Count{category00=\"web\", category01=\"fragment\", name=\"condition\"}[5m])))) /\n(sum without (instance) (delta(com_atlassian_jira_metrics_Count{category00=\"web\", category01=\"fragment\", name=\"condition\"}[5m])))",
           "interval": "",
-          "legendFormat": "{{tag_fromPluginKey}} - {{tag_conditionClassName}} (condition)",
+          "legendFormat": "{{ instance }} {{tag_fromPluginKey}} - {{tag_conditionClassName}} (condition)",
           "refId": "A"
         }
       ],
@@ -588,7 +588,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${query0}"
+        "uid": "$datasource"
       },
       "description": "Measures how long web fragment condition will take to determine whether a web fragment should be displayed or not.\n\nWeb fragments conditions determine whether a link or a section on a page should be displayed. Slow web fragment conditions lead to slow page load times especially if they are not cached. Reach out to the app vendor responsible to flag and investigate. ",
       "editable": false,
@@ -670,12 +670,12 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${query0}"
+            "uid": "$datasource"
           },
           "exemplar": true,
           "expr": "com_atlassian_jira_metrics_99thPercentile{category00=\"web\", category01=\"fragment\", name=\"condition\"}",
           "interval": "",
-          "legendFormat": "{{tag_fromPluginKey}} - {{tag_conditionClassName}} (condition)",
+          "legendFormat": "{{ instance }} {{tag_fromPluginKey}} - {{tag_conditionClassName}} (condition)",
           "refId": "A"
         }
       ],
@@ -698,7 +698,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${query0}"
+        "uid": "$datasource"
       },
       "description": "Measures how long a Soy Template web panel is taking to render.\n\nThe template renderer might be long-running. If there is a plugin with a slow Soy renderer it might be worth adding (tag__templateName) to the query and contacting the vendor responsible to investigate if long-running queries are expected.",
       "fieldConfig": {
@@ -755,7 +755,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${query0}"
+            "uid": "$datasource"
           },
           "exemplar": false,
           "expr": "avg without (instance, tag_templateName) (com_atlassian_jira_metrics_Mean{name=\"webTemplateRenderer\",tag_templateRenderer=\"soy\"})",
@@ -768,7 +768,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${query0}"
+            "uid": "$datasource"
           },
           "exemplar": false,
           "expr": "sum without (instance, tag_templateName) (com_atlassian_jira_metrics_Count{name=\"webTemplateRenderer\",tag_templateRenderer=\"soy\"})",
@@ -782,7 +782,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${query0}"
+            "uid": "$datasource"
           },
           "exemplar": false,
           "expr": "max without (instance, tag_templateName) (com_atlassian_jira_metrics_99thPercentile{name=\"webTemplateRenderer\",tag_templateRenderer=\"soy\"})",
@@ -834,7 +834,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${query0}"
+        "uid": "$datasource"
       },
       "description": "Measures how long a Soy Template web panel is taking to render.\n\nThe template renderer might be long running. Contact the vendor responsible and investigate if long running queries are expected.",
       "editable": false,
@@ -916,12 +916,12 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${query0}"
+            "uid": "$datasource"
           },
           "exemplar": true,
           "expr": "# We do this because the average of averages is not the real average. We must weigh them by the count\n(sum without (instance, tag_entityType) ((com_atlassian_jira_metrics_Mean{name=\"webTemplateRenderer\",tag_templateRenderer=\"soy\"}) * \n(delta(com_atlassian_jira_metrics_Count{name=\"webTemplateRenderer\",tag_templateRenderer=\"soy\"}[5m])))) /\n(sum without (instance, tag_entityType) (delta(com_atlassian_jira_metrics_Count{name=\"webTemplateRenderer\",tag_templateRenderer=\"soy\"}[5m])))",
           "interval": "",
-          "legendFormat": "{{tag_fromPluginKey}} - {{tag_templateName}} (template)",
+          "legendFormat": "{{ instance }} {{tag_fromPluginKey}} - {{tag_templateName}} (template)",
           "refId": "A"
         }
       ],
@@ -931,7 +931,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${query0}"
+        "uid": "$datasource"
       },
       "description": "Measures how long a Soy Template web panel is taking to render.\n\nThe template renderer might be long running. Contact the vendor responsible and investigate if long running queries are expected.",
       "editable": false,
@@ -1013,7 +1013,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${query0}"
+            "uid": "$datasource"
           },
           "exemplar": true,
           "expr": "com_atlassian_jira_metrics_99thPercentile{name=\"webTemplateRenderer\",tag_templateRenderer=\"soy\"}",
@@ -1045,7 +1045,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${query0}"
+        "uid": "$datasource"
       },
       "description": "Measures how long a Velocity template web panel is taking to render.\n\nThe template renderer might be long running. Contact the vendor responsible and investigate if long running queries are expected.",
       "fieldConfig": {
@@ -1097,7 +1097,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${query0}"
+            "uid": "$datasource"
           },
           "exemplar": false,
           "expr": "topk(500, avg without (instance, tag_templateName) (com_atlassian_jira_metrics_Mean{name=\"webTemplateRenderer\",tag_templateRenderer=\"velocity\"}) )",
@@ -1110,7 +1110,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${query0}"
+            "uid": "$datasource"
           },
           "exemplar": false,
           "expr": "sum without (instance, tag_templateName) (com_atlassian_jira_metrics_Count{name=\"webTemplateRenderer\",tag_templateRenderer=\"velocity\"})",
@@ -1124,7 +1124,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${query0}"
+            "uid": "$datasource"
           },
           "exemplar": false,
           "expr": "max without (instance, tag_templateName) (com_atlassian_jira_metrics_99thPercentile{name=\"webTemplateRenderer\",tag_templateRenderer=\"velocity\"})",
@@ -1176,7 +1176,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${query0}"
+        "uid": "$datasource"
       },
       "description": "Measures how long a Velocity template web panel is taking to render.\n\nThe template renderer might be long running. Contact the vendor responsible and investigate if long running queries are expected.",
       "editable": false,
@@ -1283,12 +1283,12 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${query0}"
+            "uid": "$datasource"
           },
           "exemplar": true,
           "expr": "# We do this because the average of averages is not the real average. We must weigh them by the count\n(sum without (instance) ((com_atlassian_jira_metrics_Mean{name=\"webTemplateRenderer\",tag_templateRenderer=\"velocity\"}) * \n(delta(com_atlassian_jira_metrics_Count{name=\"webTemplateRenderer\",tag_templateRenderer=\"velocity\"}[5m])))) /\n(sum without (instance) (delta(com_atlassian_jira_metrics_Count{name=\"webTemplateRenderer\",tag_templateRenderer=\"velocity\"}[5m])))",
           "interval": "",
-          "legendFormat": "{{tag_fromPluginKey}} - {{tag_templateName}} (template)",
+          "legendFormat": "{{ instance }} {{tag_fromPluginKey}} - {{tag_templateName}} (template)",
           "refId": "A"
         }
       ],
@@ -1298,7 +1298,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${query0}"
+        "uid": "$datasource"
       },
       "description": "Measures how long a Velocity template web panel is taking to render.\n\nThe template renderer might be long running. Contact the vendor responsible and investigate if long running queries are expected.",
       "editable": false,
@@ -1380,12 +1380,12 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${query0}"
+            "uid": "$datasource"
           },
           "exemplar": true,
           "expr": "topk(5, com_atlassian_jira_metrics_99thPercentile{name=\"webTemplateRenderer\",tag_templateRenderer=\"velocity\"})",
           "interval": "",
-          "legendFormat": "{{tag_fromPluginKey}} - {{tag_templateName}} (template)",
+          "legendFormat": "{{ instance }} {{tag_fromPluginKey}} - {{tag_templateName}} (template)",
           "refId": "A"
         }
       ],
@@ -1412,7 +1412,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${query0}"
+        "uid": "$datasource"
       },
       "description": "Measures how long web resource condition will take to determine whether a resource should be displayed or not.\n\nSlow web resource conditions lead to slow page load times especially if they are not cached. Reach out to the app vendor responsible to flag and investigate. ",
       "editable": false,
@@ -1494,12 +1494,12 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${query0}"
+            "uid": "$datasource"
           },
           "exemplar": true,
           "expr": "avg without (instance) (com_atlassian_jira_metrics_Mean{category00=\"web\", category01=\"resource\", name=\"condition\"})",
           "interval": "",
-          "legendFormat": "{{tag_fromPluginKey}} - {{tag_conditionClassName}} (condition)",
+          "legendFormat": "{{ instance }} {{tag_fromPluginKey}} - {{tag_conditionClassName}} (condition)",
           "refId": "A"
         }
       ],
@@ -1509,7 +1509,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${query0}"
+        "uid": "$datasource"
       },
       "description": "Measures how long web resource condition will take to determine whether a resource should be displayed or not.\n\nSlow web resource conditions lead to slow page load times especially if they are not cached. Reach out to the app vendor responsible to flag and investigate. ",
       "editable": false,
@@ -1591,12 +1591,12 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${query0}"
+            "uid": "$datasource"
           },
           "exemplar": true,
           "expr": "topk(5, com_atlassian_jira_metrics_99thPercentile{category00=\"web\", category01=\"resource\", name=\"condition\"})",
           "interval": "",
-          "legendFormat": "{{tag_fromPluginKey}} - {{tag_conditionClassName}} (condition)",
+          "legendFormat": "{{ instance }} {{tag_fromPluginKey}} - {{tag_conditionClassName}} (condition)",
           "refId": "A"
         }
       ],
@@ -1623,7 +1623,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${query0}"
+        "uid": "$datasource"
       },
       "description": "Use this table to quickly identify the slowest calls and some outliers using the 99th percentile response time. Use this table to figure out which endpoint to investigate then correlate it with the other timeseries panels for more detailed diagnosis ",
       "fieldConfig": {
@@ -1680,7 +1680,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${query0}"
+            "uid": "$datasource"
           },
           "exemplar": false,
           "expr": "topk(500, avg without (instance) (com_atlassian_jira_metrics_Mean{category00=\"http\", category01=\"rest\", name=\"request\"}))",
@@ -1693,7 +1693,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${query0}"
+            "uid": "$datasource"
           },
           "exemplar": false,
           "expr": "sum without (instance) (com_atlassian_jira_metrics_Count{category00=\"http\", category01=\"rest\", name=\"request\"})",
@@ -1707,7 +1707,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${query0}"
+            "uid": "$datasource"
           },
           "exemplar": false,
           "expr": "max without (instance) (com_atlassian_jira_metrics_99thPercentile{category00=\"http\", category01=\"rest\", name=\"request\"})",
@@ -1754,7 +1754,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${query0}"
+        "uid": "$datasource"
       },
       "description": "Measures HTTP responses of the REST APIs that uses the atlassian-rest module.\n\nCheck the frequency and duration of the rest requests. If excessive or very slow, consider reaching out to the app vendor and flag this issue to them.",
       "editable": false,
@@ -1836,12 +1836,12 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${query0}"
+            "uid": "$datasource"
           },
           "exemplar": false,
           "expr": "# We do this because the average of averages is not the real average. We must weigh them by the count\n(sum without (instance, tag_entityType) ((com_atlassian_jira_metrics_Mean{category00=\"http\", category01=\"rest\", name=\"request\"}) * \n(delta(com_atlassian_jira_metrics_Count{category00=\"http\", category01=\"rest\", name=\"request\"}[5m])))) /\n(sum without (instance, tag_entityType) (delta(com_atlassian_jira_metrics_Count{category00=\"http\", category01=\"rest\", name=\"request\"}[5m])))",
           "interval": "",
-          "legendFormat": "{{tag_fromPluginKey}} - {{tag_path}} (path)",
+          "legendFormat": "{{ instance }} {{tag_fromPluginKey}} - {{tag_path}} (path)",
           "refId": "A"
         }
       ],
@@ -1851,7 +1851,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${query0}"
+        "uid": "$datasource"
       },
       "description": "Measures HTTP response of the REST APIs that uses the atlassian-rest module.\n\nCheck the frequency and duration of the rest requests. If excessive or very slow, consider reaching out to the app vendor and flag this issue to the",
       "editable": false,
@@ -1933,12 +1933,12 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${query0}"
+            "uid": "$datasource"
           },
           "exemplar": true,
           "expr": "topk(5, com_atlassian_jira_metrics_99thPercentile{category00=\"http\", category01=\"rest\", name=\"request\"})",
           "interval": "",
-          "legendFormat": "{{tag_fromPluginKey}} - {{tag_path}} (path)",
+          "legendFormat": "{{ instance }} {{tag_fromPluginKey}} - {{tag_path}} (path)",
           "refId": "A"
         }
       ],
@@ -1948,7 +1948,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${query0}"
+        "uid": "$datasource"
       },
       "description": "A timeseries of plugins REST average response times regardless of which node they are running on",
       "fieldConfig": {
@@ -2023,12 +2023,12 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${query0}"
+            "uid": "$datasource"
           },
           "exemplar": true,
           "expr": "avg without (instance, tag_path, tag_action) (com_atlassian_jira_metrics_Mean{category00=\"http\",category01=\"rest\", name=\"request\"})",
           "interval": "",
-          "legendFormat": "{{tag_fromPluginKey}}",
+          "legendFormat": "{{ instance }} {{tag_fromPluginKey}}",
           "refId": "A"
         }
       ],
@@ -2051,7 +2051,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${query0}"
+        "uid": "$datasource"
       },
       "description": "Measures HTTP requests of the given unique URL that uses atlassian-sal module. \n\nCheck the frequency and duration of the http requests. If excessive or very slow, consider reaching out to the app vendor and flag this issue to them. You could also enable url optional tag to identify which urls are causing the issue, you can do so by setting a system variable like so atlassian.metrics.optional.tags.http.sal.request=url",
       "editable": false,
@@ -2133,12 +2133,12 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${query0}"
+            "uid": "$datasource"
           },
           "exemplar": true,
           "expr": "# We do this because the average of averages is not the real average. We must weigh them by the count\n(sum without (instance, tag_action) ((com_atlassian_jira_metrics_Mean{category00=\"http\", category01=\"sal\", name=\"request\"}) * \n(delta(com_atlassian_jira_metrics_Count{category00=\"http\", category01=\"sal\", name=\"request\"}[5m])))) /\n(sum without (instance, tag_action) (delta(com_atlassian_jira_metrics_Count{category00=\"http\", category01=\"sal\", name=\"request\"}[5m])))\n",
           "interval": "",
-          "legendFormat": "{{tag_pluginKeyAtCreation}}",
+          "legendFormat": "{{ instance }} {{tag_pluginKeyAtCreation}}",
           "refId": "A"
         }
       ],
@@ -2148,7 +2148,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${query0}"
+        "uid": "$datasource"
       },
       "description": "Measures HTTP requests of the given unique URL that uses atlassian-sal module. \n\nCheck the frequency and duration of the http requests. If excessive or very slow, consider reaching out to the app vendor and flag this issue to them. You could also enable url optional tag to identify which urls are causing the issue, you can do so by setting a system variable like so atlassian.metrics.optional.tags.http.sal.request=url",
       "editable": false,
@@ -2230,12 +2230,12 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${query0}"
+            "uid": "$datasource"
           },
           "exemplar": true,
           "expr": "topk(5, com_atlassian_jira_metrics_99thPercentile{category00=\"http\", category01=\"sal\", name=\"request\"})",
           "interval": "",
-          "legendFormat": "{{tag_pluginKeyAtCreation}}",
+          "legendFormat": "{{ instance }} {{tag_pluginKeyAtCreation}}",
           "refId": "A"
         }
       ],
@@ -2246,21 +2246,23 @@
   "refresh": "",
   "schemaVersion": 34,
   "style": "dark",
-  "tags": [],
+  "tags": [
+    "jira"
+  ],
   "templating": {
     "list": [
       {
         "current": {
           "selected": false,
-          "text": "Blitz",
-          "value": "Blitz"
+          "text": "default",
+          "value": "default"
         },
         "description": "Choose the data source to apply to this dashboard",
         "hide": 0,
         "includeAll": false,
-        "label": "Datasource",
+        "label": "Data Source",
         "multi": false,
-        "name": "query0",
+        "name": "datasource",
         "options": [],
         "query": "prometheus",
         "queryValue": "",
@@ -2272,13 +2274,12 @@
     ]
   },
   "time": {
-    "from": "now-1h",
+    "from": "now-6h",
     "to": "now"
   },
   "timepicker": {},
-  "timezone": "Europe/Warsaw",
-  "title": "Response times",
-  "uid": "dA8tm85nz",
-  "version": 109,
+  "timezone": "",
+  "title": "Jira Response Times",
+  "version": 1,
   "weekStart": ""
 }


### PR DESCRIPTION
This PR refactored response times dashboard to be more generic:
- added `Jira` to dashboard name,
- set dashboard version to 1,
- removed hardcoded uid,
- unified time to be 6h from now,
- removed timezone,
- added tag `jira`,
- updated variable naming,
- narrowed down legend format to instance level.